### PR TITLE
Fixes panic from overflow when subtracting durations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ impl RateLimiter {
             if self.count == max_per_time {
                 log::warn!(
                     "Hit logging threshold! Starting to ignore the previous log for {:?}",
-                    period - calculated_duration
+                    period.checked_sub(calculated_duration)
                 );
             }
         } else {


### PR DESCRIPTION
Hi Walter,

Thanks for this crate! It was exactly what I was looking for. I was hitting a panic from the subtractions of the durations. This happens when there are not too many logs, and `max_per_time` is reached in a longer duration than `period`.