### PR TITLE
Configurable throttle reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,17 +50,17 @@ for i in 0..10 {
 2024-08-24T10:49:29.198Z ERROR [log_limit_user] Rate limit log for 1
 2024-08-24T10:49:29.199Z DEBUG [log_limit_user] Loop number: 2
 2024-08-24T10:49:29.199Z ERROR [log_limit_user] Rate limit log for 2
-2024-08-24T10:49:29.199Z WARN  [log_limit] Hit logging threshold! Starting to ignore the previous log for 2.22ms
+2024-08-24T10:49:29.199Z WARN  [log_limit] [src/main.rs:40] Hit logging threshold! Starting to ignore the previous log for 2.22ms
 2024-08-24T10:49:29.200Z DEBUG [log_limit_user] Loop number: 3
 2024-08-24T10:49:29.201Z DEBUG [log_limit_user] Loop number: 4
 2024-08-24T10:49:29.203Z DEBUG [log_limit_user] Loop number: 5
-2024-08-24T10:49:29.203Z WARN  [log_limit] Ignored 2 logs since 5.52ms ago. Starting to log again...
+2024-08-24T10:49:29.203Z WARN  [log_limit] [src/main.rs:40] Ignored 2 logs since 5.52ms ago. Starting to log again...
 2024-08-24T10:49:29.203Z ERROR [log_limit_user] Rate limit log for 5
 2024-08-24T10:49:29.204Z DEBUG [log_limit_user] Loop number: 6
 2024-08-24T10:49:29.204Z ERROR [log_limit_user] Rate limit log for 6
 2024-08-24T10:49:29.205Z DEBUG [log_limit_user] Loop number: 7
 2024-08-24T10:49:29.205Z ERROR [log_limit_user] Rate limit log for 7
-2024-08-24T10:49:29.205Z WARN  [log_limit] Hit logging threshold! Starting to ignore the previous log for 2.18ms
+2024-08-24T10:49:29.205Z WARN  [log_limit] [src/main.rs:40] Hit logging threshold! Starting to ignore the previous log for 2.18ms
 2024-08-24T10:49:29.206Z DEBUG [log_limit_user] Loop number: 8
 2024-08-24T10:49:29.207Z DEBUG [log_limit_user] Loop number: 9
 ```

--- a/README.md
+++ b/README.md
@@ -65,6 +65,35 @@ for i in 0..10 {
 2024-08-24T10:49:29.207Z DEBUG [log_limit_user] Loop number: 9
 ```
 
+### Custom throttle/recovery messages
+By default the "Hit logging threshold!" / "Ignored N logs..." notices above are
+emitted via `log::warn!`. To customise the wording, level, or add structured
+fields, install a reporter once at startup with `set_reporter`:
+
+```rust
+use log_limit::{set_reporter, ThrottleNotice};
+
+set_reporter(|notice| match notice {
+    ThrottleNotice::Throttling { context, within } => {
+        log::warn!("[{context}] throttling for {within:.2?}");
+    }
+    ThrottleNotice::Resumed { context, dropped, elapsed } => {
+        log::warn!("[{context}] dropped {dropped} logs over {elapsed:.2?}");
+    }
+});
+```
+
+`context` defaults to the `file!():line!()` of the rate-limited log line. It
+can be overridden per call-site with a `context:` argument by calling the
+underlying `limit_impl!`/`global_limit_impl!` macros directly instead of the
+`[error|warn|info|debug|trace]_limit[_global]!` wrappers:
+
+```rust
+use std::time::Duration;
+
+log_limit::limit_impl!(log::Level::Info, context: format_args!("request-handler"), 3, Duration::from_millis(5), "Rate limit log for request");
+```
+
 ### TODO:
 * Do some benchmarking and optimization
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,11 +4,75 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::LazyLock;
 use std::sync::Mutex;
+use std::sync::OnceLock;
 use std::time::Duration;
 use std::time::Instant;
 
 #[cfg(test)]
 mod testing_logger;
+
+/// A throttling event handed to the reporter installed via [`set_reporter`].
+/// `context` identifies the throttled log line (source location, plus any
+/// caller-supplied label).
+pub enum ThrottleNotice<'a> {
+    /// The threshold was just reached; further logs from this site are dropped
+    /// for up to `within`.
+    Throttling {
+        context: core::fmt::Arguments<'a>,
+        within: Duration,
+    },
+    /// Logging from this site resumed after `dropped` messages were suppressed
+    /// over `elapsed`.
+    Resumed {
+        context: core::fmt::Arguments<'a>,
+        dropped: usize,
+        elapsed: Duration,
+    },
+}
+
+type Reporter = dyn Fn(&ThrottleNotice) + Send + Sync;
+static REPORTER: OnceLock<Box<Reporter>> = OnceLock::new();
+
+/// Install the reporter used to emit throttle/recovery notices. May be set
+/// once; later calls are ignored. The reporter runs only on throttle events
+/// (never on the per-log hot path) and should emit via the `log` crate
+/// directly to avoid recursing through a rate-limited macro.
+pub fn set_reporter<F>(reporter: F)
+where
+    F: Fn(&ThrottleNotice) + Send + Sync + 'static,
+{
+    let _ = REPORTER.set(Box::new(reporter));
+}
+
+#[cfg(feature = "warning-messages")]
+fn report(notice: &ThrottleNotice) {
+    match REPORTER.get() {
+        Some(reporter) => reporter(notice),
+        None => default_report(notice),
+    }
+}
+
+// Preserves the original warning wording. The `context` is available to a
+// custom reporter via `set_reporter`, but the default text ignores it.
+#[cfg(feature = "warning-messages")]
+fn default_report(notice: &ThrottleNotice) {
+    match notice {
+        ThrottleNotice::Throttling { within, .. } => {
+            log::warn!(
+                "Hit logging threshold! Starting to ignore the previous log for {:.2?}",
+                within
+            );
+        }
+        ThrottleNotice::Resumed {
+            dropped, elapsed, ..
+        } => {
+            log::warn!(
+                "Ignored {dropped} logs since {:.2?} ago. Starting to log again...",
+                elapsed
+            );
+        }
+    }
+}
 
 #[doc(hidden)]
 pub struct RateLimiter {
@@ -32,7 +96,14 @@ impl RateLimiter {
         }
     }
 
-    pub fn log_maybe(&mut self, period: Duration, max_per_time: usize, log: impl Fn()) {
+    #[cfg_attr(not(feature = "warning-messages"), allow(unused_variables))]
+    pub fn log_maybe(
+        &mut self,
+        period: Duration,
+        max_per_time: usize,
+        context: core::fmt::Arguments,
+        log: impl Fn(),
+    ) {
         let now = Instant::now();
 
         #[cfg(feature = "warning-messages")]
@@ -43,10 +114,10 @@ impl RateLimiter {
 
             #[cfg(feature = "warning-messages")]
             if self.count == max_per_time && period >= calculated_duration {
-                log::warn!(
-                    "Hit logging threshold! Starting to ignore the previous log for {:.2?}",
-                    period - calculated_duration
-                );
+                report(&ThrottleNotice::Throttling {
+                    context,
+                    within: period - calculated_duration,
+                });
                 self.logged_timeout = true;
             }
         } else {
@@ -56,10 +127,11 @@ impl RateLimiter {
                 let filtered_log_count = self.count - max_per_time;
                 #[cfg(feature = "warning-messages")]
                 if self.logged_timeout {
-                    log::warn!(
-                        "Ignored {filtered_log_count} logs since {:.2?} ago. Starting to log again...",
-                        calculated_duration
-                    );
+                    report(&ThrottleNotice::Resumed {
+                        context,
+                        dropped: filtered_log_count,
+                        elapsed: calculated_duration,
+                    });
                 }
                 self.logged_timeout = false;
                 log();
@@ -86,16 +158,23 @@ impl SynchronisedRateLimiter {
         })
     }
 
-    pub fn log_maybe(&self, period: Duration, max_per_time: usize, log: impl Fn()) {
+    #[cfg_attr(not(feature = "warning-messages"), allow(unused_variables))]
+    pub fn log_maybe(
+        &self,
+        period: Duration,
+        max_per_time: usize,
+        context: core::fmt::Arguments,
+        log: impl Fn(),
+    ) {
         let count = self.count.fetch_add(1, Ordering::Relaxed) + 1;
         if count <= max_per_time {
             log();
             #[cfg(feature = "warning-messages")]
             if count == max_per_time {
-                log::warn!(
-                    "Hit logging threshold! Starting to ignore the previous log for less than {:.2?}",
-                    period
-                );
+                report(&ThrottleNotice::Throttling {
+                    context,
+                    within: period,
+                });
             }
         } else {
             let now = Instant::now();
@@ -108,10 +187,11 @@ impl SynchronisedRateLimiter {
                 #[cfg(not(feature = "warning-messages"))]
                 let _filtered_log_count = self.count.swap(1, Ordering::Relaxed) - max_per_time - 1;
                 #[cfg(feature = "warning-messages")]
-                log::warn!(
-                    "Ignored {filtered_log_count} logs since {:.2?} ago. Starting to log again...",
-                    calculated_duration
-                );
+                report(&ThrottleNotice::Resumed {
+                    context,
+                    dropped: filtered_log_count,
+                    elapsed: calculated_duration,
+                });
                 log();
                 *timestamp = now;
             }
@@ -123,22 +203,28 @@ impl SynchronisedRateLimiter {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! global_limit_impl {
-    ($level:expr, $max_per_time:expr, $period:expr, target: $target:expr, $($arg:tt)+) => {{
+    ($level:expr, context: $context:expr, $max_per_time:expr, $period:expr, target: $target:expr, $($arg:tt)+) => {{
         use $crate::SynchronisedRateLimiter;
         use std::sync::LazyLock;
         if log::log_enabled!($level) {
             static RATE_LIMITER: LazyLock<SynchronisedRateLimiter> = SynchronisedRateLimiter::new();
-            RATE_LIMITER.log_maybe($period, $max_per_time, || log::log!(target: $target, $level, $($arg)+));
+            RATE_LIMITER.log_maybe($period, $max_per_time, $context, || log::log!(target: $target, $level, $($arg)+));
         }
     }};
-    ($level:expr, $max_per_time:expr, $period:expr, $($arg:tt)+) => {{
+    ($level:expr, context: $context:expr, $max_per_time:expr, $period:expr, $($arg:tt)+) => {{
         use $crate::SynchronisedRateLimiter;
         use std::sync::LazyLock;
         if log::log_enabled!($level) {
             static RATE_LIMITER: LazyLock<SynchronisedRateLimiter> = SynchronisedRateLimiter::new();
-            RATE_LIMITER.log_maybe($period, $max_per_time, || log::log!($level, $($arg)+));
+            RATE_LIMITER.log_maybe($period, $max_per_time, $context, || log::log!($level, $($arg)+));
         }
     }};
+    ($level:expr, $max_per_time:expr, $period:expr, target: $target:expr, $($arg:tt)+) => {
+        $crate::global_limit_impl!($level, context: format_args!("{}:{}", file!(), line!()), $max_per_time, $period, target: $target, $($arg)+)
+    };
+    ($level:expr, $max_per_time:expr, $period:expr, $($arg:tt)+) => {
+        $crate::global_limit_impl!($level, context: format_args!("{}:{}", file!(), line!()), $max_per_time, $period, $($arg)+)
+    };
 }
 
 #[macro_export]
@@ -195,7 +281,7 @@ macro_rules! trace_limit_global {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! limit_impl {
-    ($level:expr, $max_per_time:expr, $period:expr, target: $target:expr, $($arg:tt)+) => {{
+    ($level:expr, context: $context:expr, $max_per_time:expr, $period:expr, target: $target:expr, $($arg:tt)+) => {{
         use $crate::RateLimiter;
         use std::cell::RefCell;
         use std::thread_local;
@@ -208,11 +294,11 @@ macro_rules! limit_impl {
             RATE_LIMITER.with(|rate_limiter| {
                 rate_limiter
                     .borrow_mut()
-                    .log_maybe($period, $max_per_time, || log::log!(target: $target, $level, $($arg)+))
+                    .log_maybe($period, $max_per_time, $context, || log::log!(target: $target, $level, $($arg)+))
             });
         }
     }};
-    ($level:expr, $max_per_time:expr, $period:expr, $($arg:tt)+) => {{
+    ($level:expr, context: $context:expr, $max_per_time:expr, $period:expr, $($arg:tt)+) => {{
         use $crate::RateLimiter;
         use std::cell::RefCell;
         use std::thread_local;
@@ -225,10 +311,16 @@ macro_rules! limit_impl {
             RATE_LIMITER.with(|rate_limiter| {
                 rate_limiter
                     .borrow_mut()
-                    .log_maybe($period, $max_per_time, || log::log!($level, $($arg)+))
+                    .log_maybe($period, $max_per_time, $context, || log::log!($level, $($arg)+))
             });
         }
     }};
+    ($level:expr, $max_per_time:expr, $period:expr, target: $target:expr, $($arg:tt)+) => {
+        $crate::limit_impl!($level, context: format_args!("{}:{}", file!(), line!()), $max_per_time, $period, target: $target, $($arg)+)
+    };
+    ($level:expr, $max_per_time:expr, $period:expr, $($arg:tt)+) => {
+        $crate::limit_impl!($level, context: format_args!("{}:{}", file!(), line!()), $max_per_time, $period, $($arg)+)
+    };
 }
 
 #[macro_export]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,22 +52,22 @@ fn report(notice: &ThrottleNotice) {
     }
 }
 
-// Preserves the original warning wording. The `context` is available to a
-// custom reporter via `set_reporter`, but the default text ignores it.
 #[cfg(feature = "warning-messages")]
 fn default_report(notice: &ThrottleNotice) {
     match notice {
-        ThrottleNotice::Throttling { within, .. } => {
+        ThrottleNotice::Throttling { context, within } => {
             log::warn!(
-                "Hit logging threshold! Starting to ignore the previous log for {:.2?}",
+                "[{context}] Hit logging threshold! Starting to ignore the previous log for {:.2?}",
                 within
             );
         }
         ThrottleNotice::Resumed {
-            dropped, elapsed, ..
+            context,
+            dropped,
+            elapsed,
         } => {
             log::warn!(
-                "Ignored {dropped} logs since {:.2?} ago. Starting to log again...",
+                "[{context}] Ignored {dropped} logs since {:.2?} ago. Starting to log again...",
                 elapsed
             );
         }
@@ -429,11 +429,11 @@ mod tests {
                 assert_eq!(ignored_warnings.len(), 2);
                 assert_eq!(
                     "3",
-                    ignored_warnings[0].body.split_whitespace().nth(1).unwrap()
+                    ignored_warnings[0].body.split_whitespace().nth(2).unwrap()
                 );
                 assert_eq!(
                     "3",
-                    ignored_warnings[1].body.split_whitespace().nth(1).unwrap()
+                    ignored_warnings[1].body.split_whitespace().nth(2).unwrap()
                 );
             }
         })


### PR DESCRIPTION
Adds a customizable throttle/recovery message and forwards the file and linenumber via `{context}`.